### PR TITLE
chore: use derive implement Default

### DIFF
--- a/src/mem.rs
+++ b/src/mem.rs
@@ -3,14 +3,9 @@ use std::ops::RangeBounds;
 
 use super::types::KVStore;
 
+#[derive(Default)]
 pub struct MemTree {
     pub tree: BTreeMap<Vec<u8>, Vec<u8>>,
-}
-
-impl Default for MemTree {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl MemTree {

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -10,9 +10,7 @@ pub struct MemTree {
 
 impl MemTree {
     pub fn new() -> Self {
-        Self {
-            tree: BTreeMap::new(),
-        }
+        Self::default()
     }
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -9,15 +9,10 @@ use super::types::KVStore;
 
 static EMPTY_HASH: LazyLock<Output<Sha256>> = LazyLock::new(|| Sha256::digest(b""));
 
+#[derive(Default)]
 pub struct IAVLTree {
     root: Option<Box<Node>>,
     version: u64,
-}
-
-impl Default for IAVLTree {
-    fn default() -> Self {
-        IAVLTree::new()
-    }
 }
 
 impl IAVLTree {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -17,10 +17,7 @@ pub struct IAVLTree {
 
 impl IAVLTree {
     pub fn new() -> Self {
-        IAVLTree {
-            root: None,
-            version: 0,
-        }
+        Self::default()
     }
 
     pub fn root_hash(&mut self) -> &Output<Sha256> {


### PR DESCRIPTION
We don't need to manually implement the Default trait for IAVLTree and MemTree because both BTreeMap and Option already implement it through derived implementations.

```rust
#[stable(feature = "rust1", since = "1.0.0")]
impl<K, V> Default for BTreeMap<K, V> {
    /// Creates an empty `BTreeMap`.
    fn default() -> BTreeMap<K, V> {
        BTreeMap::new()
    }
}

#[stable(feature = "rust1", since = "1.0.0")]
impl<T> Default for Option<T> {
    /// Returns [`None`][Option::None].
    ///
    /// # Examples
    ///
    /// ```
    /// let opt: Option<u32> = Option::default();
    /// assert!(opt.is_none());
    /// ```
    #[inline]
    fn default() -> Option<T> {
        None
    }
}
```